### PR TITLE
Fixing the README

### DIFF
--- a/triggers/event-fired/trigger.yaml
+++ b/triggers/event-fired/trigger.yaml
@@ -1,6 +1,6 @@
 apiVersion: integration/v1
 kind: Trigger
-name: azure-eventgrid-trigger-event-fired
+name: event-fired
 version: 1
 summary: Azure EventGrid event fired
 


### PR DESCRIPTION
Mismatch between directory structure and trigger name that prevents README from being rendered: 

![image](https://user-images.githubusercontent.com/1482985/116282369-85881b80-a73f-11eb-8d3f-bdb7a083d739.png)
